### PR TITLE
example build improvements

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -330,7 +330,7 @@ two overloads are guaranteed to not be ambiguous.
 
 Range v3 forms the basis for a proposal to add ranges to the standard library
 ([N4128](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4128.html)),
-and is also be the basis for a Technical Specification on Ranges. The Technical 
+and is also be the basis for a Technical Specification on Ranges. The Technical
 Specification contains many of Range v3's concept definitions (translated into
 the actual syntax of C++20 Concepts) in addition to constrained versions of the
 STL algorithms overloaded both for iterator/sentinel pairs and for ranges. The

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,17 +1,22 @@
+# examples use a less draconian set of compiler warnings
+ranges_append_flag(RANGES_HAS_WNO_MISSING_BRACES -Wno-missing-braces)
+ranges_append_flag(RANGES_HAS_WNO_SHORTEN_64_TO_32 -Wno-shorten-64-to-32)
+ranges_append_flag(RANGES_HAS_WNO_GLOBAL_CONSTRUCTORS -Wno-global-constructors)
+
 add_executable(comprehensions comprehensions.cpp)
-add_test(test.example.comprehensions, comprehensions)
+add_test(example.comprehensions, comprehensions)
 
 add_executable(hello hello.cpp)
-add_test(test.example.hello, hello)
+add_test(example.hello, hello)
 
 add_executable(count count.cpp)
-add_test(test.example.count, count)
+add_test(example.count, count)
 
 add_executable(count_if count_if.cpp)
-add_test(test.example.count_if, count_if)
+add_test(example.count_if, count_if)
 
 # add_executable(fibonacci fibonacci.cpp)
-# add_test(test.example.fibonacci, fibonacci)
+# add_test(example.fibonacci, fibonacci)
 
 # Guarded with a variable because the calendar example causes gcc to puke.
 if(RANGES_BUILD_CALENDAR_EXAMPLE)

--- a/example/count.cpp
+++ b/example/count.cpp
@@ -9,12 +9,12 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 // Project home: https://github.com/ericniebler/range-v3
-// 
+//
 
 
 ///[count]
-// This example demonstrates counting the number of 
-// elements that match a given value. 
+// This example demonstrates counting the number of
+// elements that match a given value.
 // output...
 // vector:   2
 // array:    2

--- a/example/count_if.cpp
+++ b/example/count_if.cpp
@@ -9,7 +9,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 // Project home: https://github.com/ericniebler/range-v3
-// 
+//
 
 
 ///[count_if]
@@ -29,7 +29,7 @@ auto is_six = [](int i) -> bool { return i == 6; };
 int main() {
 
   std::vector<int> v { 6, 2, 3, 4, 5, 6 };
-  int c = ranges::count_if( v, is_six );  
+  int c = ranges::count_if( v, is_six );
   cout << "vector:   " << c << "\n"; //2
 
   std::array<int, 6> a { 6, 2, 3, 4, 5, 6 };

--- a/example/hello.cpp
+++ b/example/hello.cpp
@@ -9,7 +9,7 @@
 //  http://www.boost.org/LICENSE_1_0.txt)
 //
 // Project home: https://github.com/ericniebler/range-v3
-// 
+//
 
 ///[hello]
 #include <range/v3/all.hpp>  //get everything


### PR DESCRIPTION
* Name the targets for examples "example.foo" instead of "test.example.foo" to keep tests distinct from examples.

* Disable some of the draconian warnings that are meant to apply to the test suite, but not to examples.

* Cleanup trailing whitespace